### PR TITLE
fix: add missing dependencies (datasets, openai, python-dotenv) to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ requires-python = ">=3.11"
 dependencies = [
     "huanzhi-utils",
     "scikit-learn",
+    "datasets",
+    "python-dotenv",
+    "openai",
     "torch",
     "setuptools",
     "deepspeed==0.16.3",


### PR DESCRIPTION
While setting up the repo locally, I encountered `ModuleNotFoundError`s for the following required packages:

- `datasets` (used for loading GSM8K and other datasets)
- `openai` (used for connecting to DeepInfra's OpenAI-compatible API)

This PR adds these packages to `pyproject.toml` to ensure new contributors can set up the repo cleanly without manual installs.

Tested by running:
```bash
python -m tests.eval_api
